### PR TITLE
Add BasicAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ resource "hydra_oauth2_client" "example" {
   token_endpoint_auth_method = "none"
 }
 ```
+
+
+## Authentication
+
+Support for Basic Auth on the Hydra Admin API is available.
+
+```hcl
+provider "hydra" {
+  endpoint = "http://hydra-admin.localhost"
+
+  basic_auth_user = var.hydra_basic_auth_user
+  basic_auth_pass = var.hydra_basic_auth_pass
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/svrakitin/terraform-provider-hydra
 go 1.15
 
 require (
+	github.com/go-openapi/runtime v0.19.26
 	github.com/hashicorp/terraform-plugin-docs v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.3
 	github.com/mitchellh/mapstructure v1.4.0

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,8 +2,11 @@ package provider
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 
+	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	hydraclient "github.com/ory/hydra-client-go/client"
@@ -20,6 +23,17 @@ func New() *schema.Provider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HYDRA_ADMIN_URL", nil),
+			},
+			"basic_auth_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HYDRA_ADMIN_AUTH_USER", nil),
+			},
+			"basic_auth_pass": {
+				Type:        schema.TypeString,
+				Sensitive:   true,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HYDRA_ADMIN_AUTH_PASS", nil),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -41,11 +55,33 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 		return nil, diag.FromErr(err)
 	}
 
-	client := hydraclient.NewHTTPClientWithConfig(nil, &hydraclient.TransportConfig{
+	cfg := &hydraclient.TransportConfig{
 		Schemes:  []string{endpointURL.Scheme},
 		Host:     endpointURL.Host,
 		BasePath: endpointURL.Path,
-	})
+	}
 
+	var transport runtime.ClientTransport
+	authUser := data.Get("basic_auth_user").(string)
+	authPass := data.Get("basic_auth_pass").(string)
+	if authUser != "" && authPass != "" {
+		tr := &BasicAuthTransport{user: authUser, pass: authPass, RoundTripper: http.DefaultTransport}
+		httpClient := &http.Client{Transport: tr}
+		transport = httptransport.NewWithClient(cfg.Host, cfg.BasePath, cfg.Schemes, httpClient)
+	} else {
+		transport = httptransport.New(cfg.Host, cfg.BasePath, cfg.Schemes)
+	}
+
+	client := hydraclient.New(transport, nil)
 	return client.Admin, nil
+}
+
+type BasicAuthTransport struct {
+	user, pass string
+	http.RoundTripper
+}
+
+func (ct *BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(ct.user, ct.pass)
+	return ct.RoundTripper.RoundTrip(req)
 }


### PR DESCRIPTION
This adds support for Basic Auth on the Hydra Admin API. I decided to use basic auth rather than a bearer token as it allows us to be a little more flexible in our security (multiple users, hashed passwords at rest).