### PR TITLE
Allow JWT authorization grant type

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.46.2
+          version: v1.51.2
       - name: Run services
         run: docker-compose up -d
       - name: Test

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -105,7 +105,7 @@ if either is included, both MUST be.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
-						"refresh_token", "authorization_code", "client_credentials", "implicit",
+						"refresh_token", "authorization_code", "client_credentials", "implicit", "urn:ietf:params:oauth:grant-type:jwt-bearer",
 					}, false),
 				},
 			},


### PR DESCRIPTION
Using [JWTs as Authorization Grants](https://datatracker.ietf.org/doc/html/rfc7523#section-2.1) is supported in Hydra since Version v1.11.0. Allow the grant type in the client's schema.