### PR TITLE
Allow auth using an arbitrary HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,20 @@ provider "hydra" {
   }
 }
 ```
+
+### HTTP header
+
+Support for auth using an abitrary HTTP request header is available.  The header name defaults to `Authorization` if not otherwise set.
+
+```hcl
+provider "hydra" {
+  endpoint = "http://hydra-admin.localhost"
+
+  authentication {
+    http_header {
+      header      = var.hydra_admin_auth_header
+      credentials = var.hydra_admin_auth_credentials
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ provider "hydra" {
 
   authentication {
     http_header {
-      header      = var.hydra_admin_auth_header
-      credentials = var.hydra_admin_auth_credentials
+      name  = var.hydra_admin_auth_http_header_name
+      value = var.hydra_admin_auth_http_header_value
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ provider "hydra" {
 
 ### HTTP header
 
-Support for auth using an abitrary HTTP request header is available.  The header name defaults to `Authorization` if not otherwise set.
+Support for auth using an arbitrary HTTP request header is available.  The header name defaults to `Authorization` if not otherwise set.
 
 ```hcl
 provider "hydra" {

--- a/docs/data-sources/jwks.md
+++ b/docs/data-sources/jwks.md
@@ -27,37 +27,34 @@ data "hydra_jwks" "default" {
 
 ### Required
 
-- **name** (String)
-
-### Optional
-
-- **id** (String) The ID of this resource.
+- `name` (String)
 
 ### Read-Only
 
-- **keys** (List of Object) (see [below for nested schema](#nestedatt--keys))
+- `id` (String) The ID of this resource.
+- `keys` (List of Object) (see [below for nested schema](#nestedatt--keys))
 
 <a id="nestedatt--keys"></a>
 ### Nested Schema for `keys`
 
 Read-Only:
 
-- **alg** (String)
-- **crv** (String)
-- **d** (String)
-- **dp** (String)
-- **dq** (String)
-- **e** (String)
-- **k** (String)
-- **kid** (String)
-- **kty** (String)
-- **n** (String)
-- **p** (String)
-- **q** (String)
-- **qi** (String)
-- **use** (String)
-- **x** (String)
-- **x5c** (List of String)
-- **y** (String)
+- `alg` (String)
+- `crv` (String)
+- `d` (String)
+- `dp` (String)
+- `dq` (String)
+- `e` (String)
+- `k` (String)
+- `kid` (String)
+- `kty` (String)
+- `n` (String)
+- `p` (String)
+- `q` (String)
+- `qi` (String)
+- `use` (String)
+- `x` (String)
+- `x5c` (List of String)
+- `y` (String)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,28 +26,41 @@ provider "hydra" {
 
 ### Required
 
-- **endpoint** (String)
+- `endpoint` (String)
 
 ### Optional
 
-- **authentication** (Block List, Max: 1) Optional block to specify an authentication method which is used to access Hydra Admin API. (see [below for nested schema](#nestedblock--authentication))
+- `authentication` (Block List, Max: 1) Optional block to specify an authentication method which is used to access Hydra Admin API. (see [below for nested schema](#nestedblock--authentication))
 
 <a id="nestedblock--authentication"></a>
 ### Nested Schema for `authentication`
 
 Optional:
 
-- **basic** (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--basic))
-- **oauth2** (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--oauth2))
-- **tls** (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--tls))
+- `basic` (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--basic))
+- `http_header` (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--http_header))
+- `oauth2` (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--oauth2))
+- `tls` (Block List, Max: 1) (see [below for nested schema](#nestedblock--authentication--tls))
 
 <a id="nestedblock--authentication--basic"></a>
 ### Nested Schema for `authentication.basic`
 
 Required:
 
-- **password** (String, Sensitive)
-- **username** (String)
+- `password` (String, Sensitive)
+- `username` (String)
+
+
+<a id="nestedblock--authentication--http_header"></a>
+### Nested Schema for `authentication.http_header`
+
+Required:
+
+- `credentials` (String, Sensitive) Credentials supplied in the configured HTTP header
+
+Optional:
+
+- `header` (String) Name of the HTTP header to send for authorization.  Defaults to Authorization.
 
 
 <a id="nestedblock--authentication--oauth2"></a>
@@ -55,14 +68,14 @@ Required:
 
 Required:
 
-- **client_id** (String) Client ID
-- **client_secret** (String, Sensitive) Client Secret
-- **token_endpoint** (String) Token endpoint to request an access token
+- `client_id` (String) Client ID
+- `client_secret` (String, Sensitive) Client Secret
+- `token_endpoint` (String) Token endpoint to request an access token
 
 Optional:
 
-- **audience** (List of String) Audience for an issued access token
-- **scopes** (List of String) Scopes for an issued access token
+- `audience` (List of String) Audience for an issued access token
+- `scopes` (List of String) Scopes for an issued access token
 
 
 <a id="nestedblock--authentication--tls"></a>
@@ -70,9 +83,9 @@ Optional:
 
 Required:
 
-- **certificate** (String, Sensitive) PEM-encoded client certificate for TLS authentication.
-- **key** (String, Sensitive) PEM-encoded client certificate key for TLS authentication.
+- `certificate` (String, Sensitive) PEM-encoded client certificate for TLS authentication.
+- `key` (String, Sensitive) PEM-encoded client certificate key for TLS authentication.
 
 Optional:
 
-- **insecure_skip_verify** (Boolean) Controls whether a client verifies the server's certificate chain and host name.
+- `insecure_skip_verify` (Boolean) Controls whether a client verifies the server's certificate chain and host name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,11 +56,11 @@ Required:
 
 Required:
 
-- `credentials` (String, Sensitive) Credentials supplied in the configured HTTP header
+- `value` (String, Sensitive) Value presented in the configured HTTP header
 
 Optional:
 
-- `header` (String) Name of the HTTP header to send for authorization.  Defaults to Authorization.
+- `name` (String) Name of the HTTP header to send for authorization.  Defaults to Authorization.
 
 
 <a id="nestedblock--authentication--oauth2"></a>

--- a/docs/resources/jwks.md
+++ b/docs/resources/jwks.md
@@ -62,23 +62,26 @@ resource "hydra_jwks" "inlined" {
 
 ### Required
 
-- **name** (String)
+- `name` (String)
 
 ### Optional
 
-- **generator** (Block List, Max: 1) (see [below for nested schema](#nestedblock--generator))
-- **id** (String) The ID of this resource.
-- **key** (Block List) (see [below for nested schema](#nestedblock--key))
+- `generator` (Block List, Max: 1) (see [below for nested schema](#nestedblock--generator))
+- `key` (Block List) (see [below for nested schema](#nestedblock--key))
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--generator"></a>
 ### Nested Schema for `generator`
 
 Required:
 
-- **alg** (String)
-- **keepers** (Map of String) Arbitrary map of values that, when changed, will trigger recreation of resource.
-- **kid** (String)
-- **use** (String)
+- `alg` (String)
+- `keepers` (Map of String) Arbitrary map of values that, when changed, will trigger recreation of resource.
+- `kid` (String)
+- `use` (String)
 
 
 <a id="nestedblock--key"></a>
@@ -86,25 +89,25 @@ Required:
 
 Required:
 
-- **alg** (String)
-- **kid** (String)
-- **kty** (String)
-- **use** (String)
+- `alg` (String)
+- `kid` (String)
+- `kty` (String)
+- `use` (String)
 
 Optional:
 
-- **crv** (String)
-- **d** (String, Sensitive)
-- **dp** (String, Sensitive)
-- **dq** (String, Sensitive)
-- **e** (String, Sensitive)
-- **k** (String, Sensitive)
-- **n** (String)
-- **p** (String, Sensitive)
-- **q** (String, Sensitive)
-- **qi** (String, Sensitive)
-- **x** (String, Sensitive)
-- **x5c** (List of String)
-- **y** (String, Sensitive)
+- `crv` (String)
+- `d` (String, Sensitive)
+- `dp` (String, Sensitive)
+- `dq` (String, Sensitive)
+- `e` (String, Sensitive)
+- `k` (String, Sensitive)
+- `n` (String)
+- `p` (String, Sensitive)
+- `q` (String, Sensitive)
+- `qi` (String, Sensitive)
+- `x` (String, Sensitive)
+- `x5c` (List of String)
+- `y` (String, Sensitive)
 
 

--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -38,77 +38,80 @@ resource "hydra_oauth2_client" "example" {
 
 ### Optional
 
-- **allowed_cors_origins** (List of String)
-- **audience** (List of String)
-- **backchannel_logout_session_required** (Boolean) Boolean value specifying whether the RP requires that a sid (session ID) Claim be included in the Logout Token to identify the RP session with the OP when the backchannel_logout_uri is used. If omitted, the default value is false.
-- **backchannel_logout_uri** (String) RP URL that will cause the RP to log itself out when sent a Logout Token by the OP.
-- **client_id** (String) ID is the id for this client.
-- **client_name** (String) Name is the human-readable string name of the client to be presented to the end-user during authorization.
-- **client_secret** (String, Sensitive) Secret is the client's secret. The secret will be included in the create request as cleartext, and then never again. 
+- `allowed_cors_origins` (List of String)
+- `audience` (List of String)
+- `backchannel_logout_session_required` (Boolean) Boolean value specifying whether the RP requires that a sid (session ID) Claim be included in the Logout Token to identify the RP session with the OP when the backchannel_logout_uri is used. If omitted, the default value is false.
+- `backchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when sent a Logout Token by the OP.
+- `client_id` (String) ID is the id for this client.
+- `client_name` (String) Name is the human-readable string name of the client to be presented to the end-user during authorization.
+- `client_secret` (String, Sensitive) Secret is the client's secret. The secret will be included in the create request as cleartext, and then never again. 
 The secret is stored using BCrypt so it is impossible to recover it. Tell your users that they need to write the secret down as it will not be made available again.
-- **client_secret_expires_at** (Number) SecretExpiresAt is an integer holding the time at which the client secret will expire or 0 if it will not expire. 
+- `client_secret_expires_at` (Number) SecretExpiresAt is an integer holding the time at which the client secret will expire or 0 if it will not expire. 
 The time is represented as the number of seconds from 1970-01-01T00:00:00Z as measured in UTC until the date/time of expiration. 
 This feature is currently not supported and it's value will always be set to 0.
-- **client_uri** (String) ClientURI is an URL string of a web page providing information about the client. If present, the server SHOULD display this URL to the end-user in a clickable fashion.
-- **contacts** (List of String)
-- **frontchannel_logout_session_required** (Boolean) Boolean value specifying whether the RP requires that iss (issuer) and sid (session ID) query parameters be included to identify the RP session with the OP when the `frontchannel_logout_uri` is used. If omitted, the default value is false.
-- **frontchannel_logout_uri** (String) RP URL that will cause the RP to log itself out when rendered in an iframe by the OP. 
+- `client_uri` (String) ClientURI is an URL string of a web page providing information about the client. If present, the server SHOULD display this URL to the end-user in a clickable fashion.
+- `contacts` (List of String)
+- `frontchannel_logout_session_required` (Boolean) Boolean value specifying whether the RP requires that iss (issuer) and sid (session ID) query parameters be included to identify the RP session with the OP when the `frontchannel_logout_uri` is used. If omitted, the default value is false.
+- `frontchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when rendered in an iframe by the OP. 
 An iss (issuer) query parameter and a sid (session ID) query parameter MAY be included by the OP to enable the RP to validate the request and to determine which of the potentially multiple sessions is to be logged out; 
 if either is included, both MUST be.
-- **grant_types** (List of String)
-- **id** (String) The ID of this resource.
-- **jwk** (Block List) A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. 
+- `grant_types` (List of String)
+- `jwk` (Block List) A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. 
 A JWK Set is a JSON data structure that represents a set of JWKs. 
 A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well. (see [below for nested schema](#nestedblock--jwk))
-- **jwks_uri** (String) URL for the Client's JSON Web Key Set [JWK] document. 
+- `jwks_uri` (String) URL for the Client's JSON Web Key Set [JWK] document. 
 If the Client signs requests to the Server, it contains the signing key(s) the Server uses to validate signatures from the Client. 
 The JWK Set MAY also contain the Client's encryption keys(s), which are used by the Server to encrypt responses to the Client. 
 When both signing and encryption keys are made available, a use (Key Use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate each key's intended usage. 
 Although some algorithms allow the same key to be used for both signatures and encryption, doing so is NOT RECOMMENDED, as it is less secure. 
 The JWK x5c parameter MAY be used to provide X.509 representations of keys provided. When used, the bare key values MUST still be present and MUST match those in the certificate.
-- **logo_uri** (String) LogoURI is an URL string that references a logo for the client.
-- **metadata** (Map of String)
-- **owner** (String) Owner is a string identifying the owner of the OAuth 2.0 Client.
-- **policy_uri** (String) PolicyURI is a URL string that points to a human-readable privacy policy document that describes how the deployment organization collects, uses, retains, and discloses personal data.
-- **post_logout_redirect_uris** (List of String)
-- **redirect_uris** (List of String)
-- **request_object_signing_alg** (String) JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects sent to the OP. All Request Objects from this Client MUST be rejected, if not signed with this algorithm.
-- **request_uris** (List of String)
-- **response_types** (List of String)
-- **scopes** (List of String)
-- **sector_identifier_uri** (String) URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.
-- **subject_type** (String) SubjectType requested for responses to this Client. The subject_types_supported Discovery parameter contains a list of the supported subject_type values for this server. Valid types include `pairwise` and `public`.
-- **token_endpoint_auth_method** (String) Requested Client Authentication method for the Token Endpoint. The options are `client_secret_post`, `client_secret_basic`, `private_key_jwt`, and `none`.
-- **token_endpoint_auth_signing_alg** (String) Requested Client Authentication signing algorithm for the Token Endpoint.
-- **tos_uri** (String) TermsOfServiceURI is a URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client.
-- **userinfo_signed_response_alg** (String) JWS alg algorithm [JWA] REQUIRED for signing UserInfo Responses. 
+- `logo_uri` (String) LogoURI is an URL string that references a logo for the client.
+- `metadata` (Map of String)
+- `owner` (String) Owner is a string identifying the owner of the OAuth 2.0 Client.
+- `policy_uri` (String) PolicyURI is a URL string that points to a human-readable privacy policy document that describes how the deployment organization collects, uses, retains, and discloses personal data.
+- `post_logout_redirect_uris` (List of String)
+- `redirect_uris` (List of String)
+- `request_object_signing_alg` (String) JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects sent to the OP. All Request Objects from this Client MUST be rejected, if not signed with this algorithm.
+- `request_uris` (List of String)
+- `response_types` (List of String)
+- `scopes` (List of String)
+- `sector_identifier_uri` (String) URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.
+- `subject_type` (String) SubjectType requested for responses to this Client. The subject_types_supported Discovery parameter contains a list of the supported subject_type values for this server. Valid types include `pairwise` and `public`.
+- `token_endpoint_auth_method` (String) Requested Client Authentication method for the Token Endpoint. The options are `client_secret_post`, `client_secret_basic`, `private_key_jwt`, and `none`.
+- `token_endpoint_auth_signing_alg` (String) Requested Client Authentication signing algorithm for the Token Endpoint.
+- `tos_uri` (String) TermsOfServiceURI is a URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client.
+- `userinfo_signed_response_alg` (String) JWS alg algorithm [JWA] REQUIRED for signing UserInfo Responses. 
 If this is specified, the response will be JWT [JWT] serialized, and signed using JWS. 
 The default, if omitted, is for the UserInfo Response to return the Claims as a UTF-8 encoded JSON object using the application/json content-type.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 <a id="nestedblock--jwk"></a>
 ### Nested Schema for `jwk`
 
 Required:
 
-- **alg** (String)
-- **kid** (String)
-- **kty** (String)
-- **use** (String)
+- `alg` (String)
+- `kid` (String)
+- `kty` (String)
+- `use` (String)
 
 Optional:
 
-- **crv** (String)
-- **d** (String, Sensitive)
-- **dp** (String, Sensitive)
-- **dq** (String, Sensitive)
-- **e** (String, Sensitive)
-- **k** (String, Sensitive)
-- **n** (String)
-- **p** (String, Sensitive)
-- **q** (String, Sensitive)
-- **qi** (String, Sensitive)
-- **x** (String, Sensitive)
-- **x5c** (List of String)
-- **y** (String, Sensitive)
+- `crv` (String)
+- `d` (String, Sensitive)
+- `dp` (String, Sensitive)
+- `dq` (String, Sensitive)
+- `e` (String, Sensitive)
+- `k` (String, Sensitive)
+- `n` (String)
+- `p` (String, Sensitive)
+- `q` (String, Sensitive)
+- `qi` (String, Sensitive)
+- `x` (String, Sensitive)
+- `x5c` (List of String)
+- `y` (String, Sensitive)
 
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -275,7 +275,7 @@ type HttpHeaderAuthTransport struct {
 	Wrapped             *http.Transport
 }
 
-func (haat *HttpHeaderAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add(haat.header, haat.credentials)
-	return haat.Wrapped.RoundTrip(req)
+func (hhat *HttpHeaderAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add(hhat.header, hhat.credentials)
+	return hhat.Wrapped.RoundTrip(req)
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -66,11 +66,11 @@ func TestProvider_basicAuth(t *testing.T) {
 }
 
 func TestProvider_httpHeaderAuth(t *testing.T) {
-	header := "My-Header"
-	credentials := "t0ps3cr3t"
+	name := "My-Header"
+	value := "t0ps3cr3t"
 
 	hydraAdminStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if c := req.Header.Get(header); c != credentials {
+		if v := req.Header.Get(name); v != value {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
@@ -82,7 +82,7 @@ func TestProvider_httpHeaderAuth(t *testing.T) {
 		Providers:  testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccProviderHttpHeaderConfig, hydraAdminStub.URL, header, credentials),
+				Config: fmt.Sprintf(testAccProviderHttpHeaderConfig, hydraAdminStub.URL, name, value),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.hydra_jwks.test", "keys.#", "0"),
 				),
@@ -191,8 +191,8 @@ provider "hydra" {
 
 	authentication {
 		http_header {
-			header      = "%s"
-			credentials = "%s"
+			name  = "%s"
+			value = "%s"
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -191,8 +191,8 @@ provider "hydra" {
 
 	authentication {
 		http_header {
-			header = "%s"
-			credentials  = "%s"
+			header      = "%s"
+			credentials = "%s"
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -65,6 +65,32 @@ func TestProvider_basicAuth(t *testing.T) {
 	})
 }
 
+func TestProvider_httpHeaderAuth(t *testing.T) {
+	header := "My-Header"
+	credentials := "t0ps3cr3t"
+
+	hydraAdminStub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if c := req.Header.Get(header); c != credentials {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hydraAdminStub.Close()
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccProviderHttpHeaderConfig, hydraAdminStub.URL, header, credentials),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hydra_jwks.test", "keys.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestProvider_tlsAuth(t *testing.T) {
 	certFile := "./fixtures/tls.crt"
 	keyFile := "./fixtures/tls.key"
@@ -150,6 +176,23 @@ provider "hydra" {
 		basic {
 			username = "%s"
 			password = "%s"
+		}
+	}
+}
+
+data "hydra_jwks" "test" {
+	name = "test"
+}
+`
+
+	testAccProviderHttpHeaderConfig = `
+provider "hydra" {
+	endpoint = "%s"
+
+	authentication {
+		http_header {
+			header = "%s"
+			credentials  = "%s"
 		}
 	}
 }


### PR DESCRIPTION
This allows the Hydra client to authorize with the admin backend using an arbitrary pre-shared token set at an arbitrary HTTP header key (defaulting to `Authorization`).

I've named this "http_header" authorization.
