### PR TITLE
skip_consent support for hydra_oauth2_client resource

### DIFF
--- a/docs/data-sources/jwks.md
+++ b/docs/data-sources/jwks.md
@@ -10,8 +10,8 @@ description: |-
 
 # hydra_jwks (Data Source)
 
-A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. 
-A JWK Set is a JSON data structure that represents a set of JWKs. 
+A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key.
+A JWK Set is a JSON data structure that represents a set of JWKs.
 A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
 ## Example Usage

--- a/docs/resources/jwks.md
+++ b/docs/resources/jwks.md
@@ -10,8 +10,8 @@ description: |-
 
 # hydra_jwks (Resource)
 
-A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. 
-A JWK Set is a JSON data structure that represents a set of JWKs. 
+A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key.
+A JWK Set is a JSON data structure that represents a set of JWKs.
 A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well.
 
 ## Example Usage

--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -11,9 +11,9 @@ description: |-
 
 # hydra_oauth2_client (Resource)
 
-OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows. 
-Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities. 
-To manage ORY Hydra, you will need an OAuth 2.0 Client as well. 
+OAuth 2.0 clients are used to perform OAuth 2.0 and OpenID Connect flows.
+Usually, OAuth 2.0 clients are generated for applications which want to consume your OAuth 2.0 or OpenID Connect capabilities.
+To manage ORY Hydra, you will need an OAuth 2.0 Client as well.
 Make sure that this endpoint is well protected and only callable by first-party components.
 
 ## Example Usage
@@ -38,32 +38,33 @@ resource "hydra_oauth2_client" "example" {
 
 ### Optional
 
+- `access_token_strategy` (String) Access token strategy to use. Valid options are "jwt" and "opaque".
 - `allowed_cors_origins` (List of String)
 - `audience` (List of String)
 - `backchannel_logout_session_required` (Boolean) Boolean value specifying whether the RP requires that a sid (session ID) Claim be included in the Logout Token to identify the RP session with the OP when the backchannel_logout_uri is used. If omitted, the default value is false.
 - `backchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when sent a Logout Token by the OP.
 - `client_id` (String) ID is the id for this client.
 - `client_name` (String) Name is the human-readable string name of the client to be presented to the end-user during authorization.
-- `client_secret` (String, Sensitive) Secret is the client's secret. The secret will be included in the create request as cleartext, and then never again. 
+- `client_secret` (String, Sensitive) Secret is the client's secret. The secret will be included in the create request as cleartext, and then never again.
 The secret is stored using BCrypt so it is impossible to recover it. Tell your users that they need to write the secret down as it will not be made available again.
-- `client_secret_expires_at` (Number) SecretExpiresAt is an integer holding the time at which the client secret will expire or 0 if it will not expire. 
-The time is represented as the number of seconds from 1970-01-01T00:00:00Z as measured in UTC until the date/time of expiration. 
+- `client_secret_expires_at` (Number) SecretExpiresAt is an integer holding the time at which the client secret will expire or 0 if it will not expire.
+The time is represented as the number of seconds from 1970-01-01T00:00:00Z as measured in UTC until the date/time of expiration.
 This feature is currently not supported and it's value will always be set to 0.
 - `client_uri` (String) ClientURI is an URL string of a web page providing information about the client. If present, the server SHOULD display this URL to the end-user in a clickable fashion.
 - `contacts` (List of String)
 - `frontchannel_logout_session_required` (Boolean) Boolean value specifying whether the RP requires that iss (issuer) and sid (session ID) query parameters be included to identify the RP session with the OP when the `frontchannel_logout_uri` is used. If omitted, the default value is false.
-- `frontchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when rendered in an iframe by the OP. 
-An iss (issuer) query parameter and a sid (session ID) query parameter MAY be included by the OP to enable the RP to validate the request and to determine which of the potentially multiple sessions is to be logged out; 
+- `frontchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when rendered in an iframe by the OP.
+An iss (issuer) query parameter and a sid (session ID) query parameter MAY be included by the OP to enable the RP to validate the request and to determine which of the potentially multiple sessions is to be logged out;
 if either is included, both MUST be.
 - `grant_types` (List of String)
-- `jwk` (Block List) A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key. 
-A JWK Set is a JSON data structure that represents a set of JWKs. 
+- `jwk` (Block List) A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key.
+A JWK Set is a JSON data structure that represents a set of JWKs.
 A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well. (see [below for nested schema](#nestedblock--jwk))
-- `jwks_uri` (String) URL for the Client's JSON Web Key Set [JWK] document. 
-If the Client signs requests to the Server, it contains the signing key(s) the Server uses to validate signatures from the Client. 
-The JWK Set MAY also contain the Client's encryption keys(s), which are used by the Server to encrypt responses to the Client. 
-When both signing and encryption keys are made available, a use (Key Use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate each key's intended usage. 
-Although some algorithms allow the same key to be used for both signatures and encryption, doing so is NOT RECOMMENDED, as it is less secure. 
+- `jwks_uri` (String) URL for the Client's JSON Web Key Set [JWK] document.
+If the Client signs requests to the Server, it contains the signing key(s) the Server uses to validate signatures from the Client.
+The JWK Set MAY also contain the Client's encryption keys(s), which are used by the Server to encrypt responses to the Client.
+When both signing and encryption keys are made available, a use (Key Use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate each key's intended usage.
+Although some algorithms allow the same key to be used for both signatures and encryption, doing so is NOT RECOMMENDED, as it is less secure.
 The JWK x5c parameter MAY be used to provide X.509 representations of keys provided. When used, the bare key values MUST still be present and MUST match those in the certificate.
 - `logo_uri` (String) LogoURI is an URL string that references a logo for the client.
 - `metadata` (Map of String)
@@ -76,12 +77,13 @@ The JWK x5c parameter MAY be used to provide X.509 representations of keys provi
 - `response_types` (List of String)
 - `scopes` (List of String)
 - `sector_identifier_uri` (String) URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.
+- `skip_consent` (Boolean) SkipConsent skips the consent screen for this client. This field can only be set from the admin API.
 - `subject_type` (String) SubjectType requested for responses to this Client. The subject_types_supported Discovery parameter contains a list of the supported subject_type values for this server. Valid types include `pairwise` and `public`.
 - `token_endpoint_auth_method` (String) Requested Client Authentication method for the Token Endpoint. The options are `client_secret_post`, `client_secret_basic`, `private_key_jwt`, and `none`.
 - `token_endpoint_auth_signing_alg` (String) Requested Client Authentication signing algorithm for the Token Endpoint.
 - `tos_uri` (String) TermsOfServiceURI is a URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client.
-- `userinfo_signed_response_alg` (String) JWS alg algorithm [JWA] REQUIRED for signing UserInfo Responses. 
-If this is specified, the response will be JWT [JWT] serialized, and signed using JWS. 
+- `userinfo_signed_response_alg` (String) JWS alg algorithm [JWA] REQUIRED for signing UserInfo Responses.
+If this is specified, the response will be JWT [JWT] serialized, and signed using JWS.
 The default, if omitted, is for the UserInfo Response to return the Claims as a UTF-8 encoded JSON object using the application/json content-type.
 
 ### Read-Only

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -195,6 +195,11 @@ The JWK x5c parameter MAY be used to provide X.509 representations of keys provi
 				Optional:    true,
 				Description: "URL using the https scheme to be used in calculating Pseudonymous Identifiers by the OP. The URL references a file with a single JSON array of redirect_uri values.",
 			},
+			"skip_consent": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "SkipConsent skips the consent screen for this client. This field can only be set from the admin API.",
+			},
 			"subject_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -332,6 +337,7 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	data.Set("request_uris", oAuthClient.RequestUris)
 	data.Set("response_types", oAuthClient.ResponseTypes)
 	data.Set("sector_identifier_uri", oAuthClient.GetSectorIdentifierUri())
+	data.Set("skip_consent", oAuthClient.SkipConsent)
 	data.Set("subject_type", oAuthClient.SubjectType)
 	if oAuthClient.Scope == nil {
 		data.Set("scopes", oAuthClient.Scope)
@@ -387,6 +393,9 @@ func dataToClient(data *schema.ResourceData) *hydra.OAuth2Client {
 	client.RequestUris = strSlice(data.Get("request_uris").([]interface{}))
 	client.ResponseTypes = strSlice(data.Get("response_types").([]interface{}))
 	client.SetSectorIdentifierUri(data.Get("sector_identifier_uri").(string))
+	if sc, ok := data.GetOk("skip_consent"); ok {
+		client.SkipConsent = ptr(sc.(bool))
+	}
 	if st, ok := data.GetOk("subject_type"); ok {
 		client.SubjectType = ptr(st.(string))
 	}


### PR DESCRIPTION
Adds support for the `skip_consent` parameter for `hydra_oauth2_client` (also requested in https://github.com/svrakitin/terraform-provider-hydra/issues/13).