### PR TITLE
add token lifespan support for different grant and token types in oauth2_client

### DIFF
--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -41,8 +41,12 @@ resource "hydra_oauth2_client" "example" {
 - `access_token_strategy` (String) Access token strategy to use. Valid options are "jwt" and "opaque".
 - `allowed_cors_origins` (List of String)
 - `audience` (List of String)
+- `authorization_code_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
+- `authorization_code_grant_id_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
+- `authorization_code_grant_refresh_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `backchannel_logout_session_required` (Boolean) Boolean value specifying whether the RP requires that a sid (session ID) Claim be included in the Logout Token to identify the RP session with the OP when the backchannel_logout_uri is used. If omitted, the default value is false.
 - `backchannel_logout_uri` (String) RP URL that will cause the RP to log itself out when sent a Logout Token by the OP.
+- `client_credentials_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `client_id` (String) ID is the id for this client.
 - `client_name` (String) Name is the human-readable string name of the client to be presented to the end-user during authorization.
 - `client_secret` (String, Sensitive) Secret is the client's secret. The secret will be included in the create request as cleartext, and then never again.
@@ -57,6 +61,8 @@ This feature is currently not supported and it's value will always be set to 0.
 An iss (issuer) query parameter and a sid (session ID) query parameter MAY be included by the OP to enable the RP to validate the request and to determine which of the potentially multiple sessions is to be logged out;
 if either is included, both MUST be.
 - `grant_types` (List of String)
+- `implicit_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
+- `implicit_grant_id_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `jwk` (Block List) A JSON Web Key (JWK) is a JavaScript Object Notation (JSON) data structure that represents a cryptographic key.
 A JWK Set is a JSON data structure that represents a set of JWKs.
 A JSON Web Key is identified by its set and key id. ORY Hydra uses this functionality to store cryptographic keys used for TLS and JSON Web Tokens (such as OpenID Connect ID tokens), and allows storing user-defined keys as well. (see [below for nested schema](#nestedblock--jwk))
@@ -66,12 +72,16 @@ The JWK Set MAY also contain the Client's encryption keys(s), which are used by 
 When both signing and encryption keys are made available, a use (Key Use) parameter value is REQUIRED for all keys in the referenced JWK Set to indicate each key's intended usage.
 Although some algorithms allow the same key to be used for both signatures and encryption, doing so is NOT RECOMMENDED, as it is less secure.
 The JWK x5c parameter MAY be used to provide X.509 representations of keys provided. When used, the bare key values MUST still be present and MUST match those in the certificate.
+- `jwt_bearer_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `logo_uri` (String) LogoURI is an URL string that references a logo for the client.
 - `metadata` (Map of String)
 - `owner` (String) Owner is a string identifying the owner of the OAuth 2.0 Client.
 - `policy_uri` (String) PolicyURI is a URL string that points to a human-readable privacy policy document that describes how the deployment organization collects, uses, retains, and discloses personal data.
 - `post_logout_redirect_uris` (List of String)
 - `redirect_uris` (List of String)
+- `refresh_token_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
+- `refresh_token_grant_id_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
+- `refresh_token_grant_refresh_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `request_object_signing_alg` (String) JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects sent to the OP. All Request Objects from this Client MUST be rejected, if not signed with this algorithm.
 - `request_uris` (List of String)
 - `response_types` (List of String)

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -1,5 +1,11 @@
 package provider
 
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
 func ptr[T any](v T) *T {
 	return &v
 }
@@ -10,4 +16,19 @@ func strSlice(items []interface{}) []string {
 		result[i] = item.(string)
 	}
 	return result
+}
+
+// diffSuppressMatchingDurationStrings compares two string time durations and returns true if they are equal, regardless of formatting.
+func diffSuppressMatchingDurationStrings(k, old, new string, d *schema.ResourceData) bool {
+	oldDuration, err := time.ParseDuration(old)
+	if err != nil {
+		return false
+	}
+
+	newDuration, err := time.ParseDuration(new)
+	if err != nil {
+		return false
+	}
+
+	return oldDuration == newDuration
 }

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -242,6 +243,76 @@ The JWK x5c parameter MAY be used to provide X.509 representations of keys provi
 If this is specified, the response will be JWT [JWT] serialized, and signed using JWS.
 The default, if omitted, is for the UserInfo Response to return the Claims as a UTF-8 encoded JSON object using the application/json content-type.`,
 			},
+			"authorization_code_grant_access_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"authorization_code_grant_id_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"authorization_code_grant_refresh_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"client_credentials_grant_access_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"implicit_grant_access_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"implicit_grant_id_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"jwt_bearer_grant_access_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"refresh_token_grant_access_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"refresh_token_grant_id_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
+			"refresh_token_grant_refresh_token_lifespan": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Specify a time duration in milliseconds, seconds, minutes, hours.",
+				ValidateFunc:     validation.StringMatch(regexp.MustCompile(`^([0-9]+(ns|us|ms|s|m|h))*$`), "Specify a time duration in milliseconds, seconds, minutes, hours."),
+				DiffSuppressFunc: diffSuppressMatchingDurationStrings,
+			},
 		},
 		CreateContext: createOAuth2ClientResource,
 		ReadContext:   readOAuth2ClientResource,
@@ -348,6 +419,16 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	data.Set("token_endpoint_auth_signing_alg", oAuthClient.TokenEndpointAuthSigningAlg)
 	data.Set("tos_uri", oAuthClient.GetTosUri())
 	data.Set("userinfo_signed_response_alg", oAuthClient.UserinfoSignedResponseAlg)
+	data.Set("authorization_code_grant_access_token_lifespan", oAuthClient.AuthorizationCodeGrantAccessTokenLifespan)
+	data.Set("authorization_code_grant_id_token_lifespan", oAuthClient.AuthorizationCodeGrantIdTokenLifespan)
+	data.Set("authorization_code_grant_refresh_token_lifespan", oAuthClient.AuthorizationCodeGrantRefreshTokenLifespan)
+	data.Set("client_credentials_grant_access_token_lifespan", oAuthClient.ClientCredentialsGrantAccessTokenLifespan)
+	data.Set("implicit_grant_access_token_lifespan", oAuthClient.ImplicitGrantAccessTokenLifespan)
+	data.Set("implicit_grant_id_token_lifespan", oAuthClient.ImplicitGrantIdTokenLifespan)
+	data.Set("jwt_bearer_grant_access_token_lifespan", oAuthClient.JwtBearerGrantAccessTokenLifespan)
+	data.Set("refresh_token_grant_access_token_lifespan", oAuthClient.RefreshTokenGrantAccessTokenLifespan)
+	data.Set("refresh_token_grant_id_token_lifespan", oAuthClient.RefreshTokenGrantIdTokenLifespan)
+	data.Set("refresh_token_grant_refresh_token_lifespan", oAuthClient.RefreshTokenGrantRefreshTokenLifespan)
 	return nil
 }
 
@@ -412,6 +493,36 @@ func dataToClient(data *schema.ResourceData) *hydra.OAuth2Client {
 	client.SetTosUri(data.Get("tos_uri").(string))
 	if usra, ok := data.GetOk("userinfo_signed_response_alg"); ok {
 		client.UserinfoSignedResponseAlg = ptr(usra.(string))
+	}
+	if acaatls, ok := data.GetOk("authorization_code_grant_access_token_lifespan"); ok {
+		client.AuthorizationCodeGrantAccessTokenLifespan = ptr(acaatls.(string))
+	}
+	if acaitls, ok := data.GetOk("authorization_code_grant_id_token_lifespan"); ok {
+		client.AuthorizationCodeGrantIdTokenLifespan = ptr(acaitls.(string))
+	}
+	if acartls, ok := data.GetOk("authorization_code_grant_refresh_token_lifespan"); ok {
+		client.AuthorizationCodeGrantRefreshTokenLifespan = ptr(acartls.(string))
+	}
+	if ccatls, ok := data.GetOk("client_credentials_grant_access_token_lifespan"); ok {
+		client.ClientCredentialsGrantAccessTokenLifespan = ptr(ccatls.(string))
+	}
+	if igatls, ok := data.GetOk("implicit_grant_access_token_lifespan"); ok {
+		client.ImplicitGrantAccessTokenLifespan = ptr(igatls.(string))
+	}
+	if igitls, ok := data.GetOk("implicit_grant_id_token_lifespan"); ok {
+		client.ImplicitGrantIdTokenLifespan = ptr(igitls.(string))
+	}
+	if jbgatls, ok := data.GetOk("jwt_bearer_grant_access_token_lifespan"); ok {
+		client.JwtBearerGrantAccessTokenLifespan = ptr(jbgatls.(string))
+	}
+	if rtgatls, ok := data.GetOk("refresh_token_grant_access_token_lifespan"); ok {
+		client.RefreshTokenGrantAccessTokenLifespan = ptr(rtgatls.(string))
+	}
+	if rtgitls, ok := data.GetOk("refresh_token_grant_id_token_lifespan"); ok {
+		client.RefreshTokenGrantIdTokenLifespan = ptr(rtgitls.(string))
+	}
+	if rtgrtls, ok := data.GetOk("refresh_token_grant_refresh_token_lifespan"); ok {
+		client.RefreshTokenGrantRefreshTokenLifespan = ptr(rtgrtls.(string))
 	}
 	return client
 }


### PR DESCRIPTION
Added missing token lifespan arguments to `oauth2_client` as per Hydra HTTP API (https://www.ory.sh/docs/hydra/reference/api#tag/oAuth2/operation/createOAuth2Client). Added also rudimentary diff suppression as Hydra converts the values internally and will cause unnecessary diffs in Terraform plans.