### PR TITLE
add support for retry configurations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ provider "hydra" {
 ### Optional
 
 - `authentication` (Block List, Max: 1) Optional block to specify an authentication method which is used to access Hydra Admin API. (see [below for nested schema](#nestedblock--authentication))
+- `retry` (Block List, Max: 1) Optional block to configure retry behavior for API requests. (see [below for nested schema](#nestedblock--retry))
 
 <a id="nestedblock--authentication"></a>
 ### Nested Schema for `authentication`
@@ -89,3 +90,15 @@ Required:
 Optional:
 
 - `insecure_skip_verify` (Boolean) Controls whether a client verifies the server's certificate chain and host name.
+
+
+
+<a id="nestedblock--retry"></a>
+### Nested Schema for `retry`
+
+Optional:
+
+- `enabled` (Boolean) Enable or disable retry behavior.
+- `max_elapsed_time` (String) Maximum time to spend retrying requests.
+- `max_interval` (String) Maximum interval between retries.
+- `randomization_factor` (Number) Randomization factor to add jitter to retry intervals.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ provider "hydra" {
 ### Optional
 
 - `authentication` (Block List, Max: 1) Optional block to specify an authentication method which is used to access Hydra Admin API. (see [below for nested schema](#nestedblock--authentication))
-- `retry` (Block List, Max: 1) Optional block to configure retry behavior for API requests. (see [below for nested schema](#nestedblock--retry))
+- `retry_policy` (Block List, Max: 1) Optional block to configure retry behavior for API requests. (see [below for nested schema](#nestedblock--retry_policy))
 
 <a id="nestedblock--authentication"></a>
 ### Nested Schema for `authentication`
@@ -93,8 +93,8 @@ Optional:
 
 
 
-<a id="nestedblock--retry"></a>
-### Nested Schema for `retry`
+<a id="nestedblock--retry_policy"></a>
+### Nested Schema for `retry_policy`
 
 Optional:
 

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/provider/data_source_jwks.go
+++ b/internal/provider/data_source_jwks.go
@@ -32,7 +32,7 @@ A JSON Web Key is identified by its set and key id. ORY Hydra uses this function
 func readJWKSDataSource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	data.SetId(data.Get("name").(string))
 
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	var jsonWebKeySet *hydra.JsonWebKeySet
 
@@ -41,7 +41,7 @@ func readJWKSDataSource(ctx context.Context, data *schema.ResourceData, meta int
 		var resp *http.Response
 		jsonWebKeySet, resp, err = hydraClient.JwkApi.GetJsonWebKeySet(ctx, data.Id()).Execute()
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -37,7 +37,7 @@ func diffSuppressMatchingDurationStrings(k, old, new string, d *schema.ResourceD
 }
 
 // retryThrottledHydraAction executes the fn function and if backOff is set, retries the function if the request is throttled.
-func retryThrottledHydraAction(fn func() (*http.Response, error), backOff backoff.BackOff) error {
+func retryThrottledHydraAction(fn func() (*http.Response, error), backOff *backoff.ExponentialBackOff) error {
 	if backOff == nil {
 		_, err := fn()
 		return err

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -37,8 +38,8 @@ func diffSuppressMatchingDurationStrings(k, old, new string, d *schema.ResourceD
 }
 
 // retryThrottledHydraAction executes the fn function and if backOff is set, retries the function if the request is throttled.
-func retryThrottledHydraAction(fn func() (*http.Response, error), backOff *backoff.ExponentialBackOff) error {
-	if backOff == nil {
+func retryThrottledHydraAction(fn func() (*http.Response, error), backOff backoff.BackOff) error {
+	if backOff == nil || reflect.ValueOf(backOff).IsNil() {
 		_, err := fn()
 		return err
 	}

--- a/internal/provider/helper.go
+++ b/internal/provider/helper.go
@@ -37,7 +37,7 @@ func diffSuppressMatchingDurationStrings(k, old, new string, d *schema.ResourceD
 }
 
 // retryThrottledHydraAction executes the fn function and if backOff is set, retries the function if the request is throttled.
-func retryThrottledHydraAction(fn func() (*http.Response, error), backOff *backoff.ExponentialBackOff) error {
+func retryThrottledHydraAction(fn func() (*http.Response, error), backOff backoff.BackOff) error {
 	if backOff == nil {
 		_, err := fn()
 		return err

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,7 +22,7 @@ func init() {
 	schema.DescriptionKind = schema.StringMarkdown
 }
 
-type HydraConfig struct {
+type ClientConfig struct {
 	hydraClient *hydra.APIClient
 	backOff     *backoff.ExponentialBackOff
 }
@@ -35,7 +35,7 @@ func New() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HYDRA_ADMIN_URL", nil),
 			},
-			"retry": {
+			"retry_policy": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
@@ -232,7 +232,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 	}
 
 	var backOff *backoff.ExponentialBackOff
-	if retry, ok := data.GetOk("retry.0"); ok && data.Get("retry.0.enabled").(bool) {
+	if retry, ok := data.GetOk("retry_policy.0"); ok && data.Get("retry_policy.0.enabled").(bool) {
 		backOff = backoff.NewExponentialBackOff()
 
 		retryConfig := retry.(map[string]interface{})
@@ -246,7 +246,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 		backOff.RandomizationFactor = randomizationFactor
 	}
 
-	return &HydraConfig{
+	return &ClientConfig{
 		hydraClient: hydra.NewAPIClient(cfg),
 		backOff:     backOff,
 	}, nil

--- a/internal/provider/resource_jwks.go
+++ b/internal/provider/resource_jwks.go
@@ -77,7 +77,7 @@ func createJWKSResource(ctx context.Context, data *schema.ResourceData, meta int
 }
 
 func generateJWKSResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	setName := data.Get("name").(string)
 	generators := data.Get("generator").([]interface{})
@@ -86,7 +86,7 @@ func generateJWKSResource(ctx context.Context, data *schema.ResourceData, meta i
 	err := retryThrottledHydraAction(func() (*http.Response, error) {
 		_, resp, err := hydraClient.JwkApi.CreateJsonWebKeySet(ctx, setName).CreateJsonWebKeySet(*dataToJWKGeneratorRequest(generator)).Execute()
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -97,7 +97,7 @@ func generateJWKSResource(ctx context.Context, data *schema.ResourceData, meta i
 }
 
 func readJWKSResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 	var jsonWebKeySet *hydra.JsonWebKeySet
 
 	err := retryThrottledHydraAction(func() (*http.Response, error) {
@@ -105,7 +105,7 @@ func readJWKSResource(ctx context.Context, data *schema.ResourceData, meta inter
 		var resp *http.Response
 		jsonWebKeySet, resp, err = hydraClient.JwkApi.GetJsonWebKeySet(ctx, data.Id()).Execute()
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,14 +116,14 @@ func readJWKSResource(ctx context.Context, data *schema.ResourceData, meta inter
 }
 
 func updateJWKSResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	setName := data.Get("name").(string)
 
 	err := retryThrottledHydraAction(func() (*http.Response, error) {
 		_, resp, err := hydraClient.JwkApi.SetJsonWebKeySet(ctx, setName).JsonWebKeySet(*dataToJWKS(data, "key")).Execute()
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -134,13 +134,13 @@ func updateJWKSResource(ctx context.Context, data *schema.ResourceData, meta int
 }
 
 func deleteJWKSResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	setName := data.Get("name").(string)
 
 	err := retryThrottledHydraAction(func() (*http.Response, error) {
 		return hydraClient.JwkApi.DeleteJsonWebKeySet(ctx, setName).Execute()
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -322,7 +322,7 @@ The default, if omitted, is for the UserInfo Response to return the Claims as a 
 }
 
 func createOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	var oAuth2Client *hydra.OAuth2Client
 
@@ -333,7 +333,7 @@ func createOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, 
 		var resp *http.Response
 		oAuth2Client, resp, err = hydraClient.OAuth2Api.CreateOAuth2Client(ctx).OAuth2Client(*client).Execute()
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -342,7 +342,7 @@ func createOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, 
 }
 
 func readOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	var oAuth2Client *hydra.OAuth2Client
 
@@ -353,7 +353,7 @@ func readOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, me
 		oAuth2Client, resp, err = hydraClient.OAuth2Api.GetOAuth2Client(ctx, data.Id()).Execute()
 
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		var genericOpenAPIError *hydra.GenericOpenAPIError
 		if errors.As(err, &genericOpenAPIError) {
@@ -370,7 +370,7 @@ func readOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, me
 }
 
 func updateOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	oAuthClient := dataToClient(data)
 
@@ -380,7 +380,7 @@ func updateOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, 
 		oAuthClient, resp, err = hydraClient.OAuth2Api.SetOAuth2Client(ctx, data.Id()).OAuth2Client(*oAuthClient).Execute()
 
 		return resp, err
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -389,11 +389,11 @@ func updateOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, 
 }
 
 func deleteOAuth2ClientResource(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	hydraClient := meta.(*HydraConfig).hydraClient
+	hydraClient := meta.(*ClientConfig).hydraClient
 
 	err := retryThrottledHydraAction(func() (*http.Response, error) {
 		return hydraClient.OAuth2Api.DeleteOAuth2Client(ctx, data.Id()).Execute()
-	}, meta.(*HydraConfig).backOff)
+	}, meta.(*ClientConfig).backOff)
 
 	return diag.FromErr(err)
 }


### PR DESCRIPTION
This PR attempts to fix the issues we reported in https://github.com/svrakitin/terraform-provider-hydra/issues/19 by introducing a configurable backoff-retry wrapper which jitter for Hydra SDK calls to more gracefully handle the rate-limiting.

By default the retry is disabled and needs to be explicitly enabled to maintain existing provider behavior and not surprise anyone.

The implementation might be a bit rough around the edges, and mainly tried to quickly get the issues we are facing sorted, so happy to refactor as needed if other better approaches are thought of. :)