### PR TITLE
Add Support for Nested Metadata Configuration in OAuth2 Client Using JSON Format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           version: v1.55.2
       - name: Run services
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Test
         env:
           HYDRA_ADMIN_URL: http://localhost:4445

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,9 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -21,12 +24,15 @@ builds:
       - goos: darwin
         goarch: "386"
     binary: "{{ .ProjectName }}_v{{ .Version }}"
+
 archives:
   - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
   algorithm: sha256
+
 signs:
   - artifacts: checksum
     args:
@@ -37,7 +43,9 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
+
 release:
   draft: true
+
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,4 +48,4 @@ release:
   draft: true
 
 changelog:
-  skip: true
+  disable: true

--- a/docs/resources/oauth2_client.md
+++ b/docs/resources/oauth2_client.md
@@ -26,7 +26,7 @@ resource "hydra_oauth2_client" "example" {
 	metadata = {
 		"first_party" = true
 	}
-    
+
 	redirect_uris = ["http://localhost:8080/callback"]
 	response_types = ["code"]
 	token_endpoint_auth_method = "none"
@@ -75,6 +75,16 @@ The JWK x5c parameter MAY be used to provide X.509 representations of keys provi
 - `jwt_bearer_grant_access_token_lifespan` (String) Specify a time duration in milliseconds, seconds, minutes, hours.
 - `logo_uri` (String) LogoURI is an URL string that references a logo for the client.
 - `metadata` (Map of String)
+- `metadata_json` (String) A JSON-encoded string representing complex, nested metadata. This allows for more advanced configurations compared to the flat key-value pairs in the `metadata` field. Use `jsonencode` to provide this value in Terraform configurations. This field conflicts with `metadata`.
+#### Example
+```terraform
+metadata_json = jsonencode({
+  "nested_key" = {
+    "inner_key" = "value"
+  },
+  "first_party" = true
+})
+```
 - `owner` (String) Owner is a string identifying the owner of the OAuth 2.0 Client.
 - `policy_uri` (String) PolicyURI is a URL string that points to a human-readable privacy policy document that describes how the deployment organization collects, uses, retains, and discloses personal data.
 - `post_logout_redirect_uris` (List of String)
@@ -125,5 +135,3 @@ Optional:
 - `x` (String, Sensitive)
 - `x5c` (List of String)
 - `y` (String, Sensitive)
-
-

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -440,7 +440,6 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 				continue
 			default:
 				useMetadataJSON = true
-				break
 			}
 		}
 		// If metadata contains nested structures or non-string values, use metadata_json

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -432,15 +432,18 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	data.Set("jwks_uri", oAuthClient.GetJwksUri())
 	data.Set("logo_uri", oAuthClient.GetLogoUri())
 	if metadata, ok := oAuthClient.Metadata.(map[string]interface{}); ok {
-		// Check if any nested maps exist in metadata
+		// Check if any nested maps or non-string values exist in metadata
 		useMetadataJSON := false
 		for _, v := range metadata {
-			if _, isMap := v.(map[string]interface{}); isMap {
+			switch v.(type) {
+			case string:
+				continue
+			default:
 				useMetadataJSON = true
 				break
 			}
 		}
-		// If metadata contains nested structures, use metadata_json
+		// If metadata contains nested structures or non-string values, use metadata_json
 		if useMetadataJSON {
 			metadataJSON, err := json.Marshal(metadata)
 			if err != nil {
@@ -449,7 +452,7 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 			data.Set("metadata_json", string(metadataJSON))
 			data.Set("metadata", nil)
 		} else {
-			// If no nested structures, use metadata
+			// If no nested structures or non-string values, use metadata
 			data.Set("metadata", metadata)
 			data.Set("metadata_json", nil)
 		}

--- a/internal/provider/resource_oauth2_client.go
+++ b/internal/provider/resource_oauth2_client.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 	"encoding/json"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -432,19 +431,12 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	dataFromJWKS(data, jwks, "jwk")
 	data.Set("jwks_uri", oAuthClient.GetJwksUri())
 	data.Set("logo_uri", oAuthClient.GetLogoUri())
-	if data.Get("metadata") != nil {
-		fmt.Println("client data")
-		fmt.Println(oAuthClient.Metadata)
+	if len(data.Get("metadata").(map[string]interface{})) > 0 {
 		data.Set("metadata", oAuthClient.Metadata)
-	} else {
-		data.Set("metadata", nil)
 	}
-	if data.Get("metadata_json") != nil {
-		//client_metadata = oAuthClient.Metadata
+	if data.Get("metadata_json") != "" {
 		metadata_json, _ := json.Marshal(oAuthClient.Metadata)
 		data.Set("metadata_json", metadata_json)
-	} else {
-		data.Set("metadata_json", nil)
 	}
 	data.Set("owner", oAuthClient.Owner)
 	data.Set("policy_uri", oAuthClient.GetPolicyUri())
@@ -475,8 +467,6 @@ func dataFromClient(data *schema.ResourceData, oAuthClient *hydra.OAuth2Client) 
 	data.Set("refresh_token_grant_access_token_lifespan", oAuthClient.RefreshTokenGrantAccessTokenLifespan)
 	data.Set("refresh_token_grant_id_token_lifespan", oAuthClient.RefreshTokenGrantIdTokenLifespan)
 	data.Set("refresh_token_grant_refresh_token_lifespan", oAuthClient.RefreshTokenGrantRefreshTokenLifespan)
-	fmt.Println("Setdata")
-	fmt.Println(data)
 	return nil
 }
 
@@ -509,17 +499,14 @@ func dataToClient(data *schema.ResourceData) *hydra.OAuth2Client {
 	}
 	client.SetJwksUri(data.Get("jwks_uri").(string))
 	client.SetLogoUri(data.Get("logo_uri").(string))
-	if data.Get("metadata") != nil {
-		fmt.Println(data.Get("metadata"))
+	if len(data.Get("metadata").(map[string]interface{})) > 0 {
 		client.Metadata = data.Get("metadata")
-		//fmt.Println(client.Metadata)
 	}
-	if data.Get("metadata_json") != nil {
+	if data.Get("metadata_json") != "" {
 		metadata_string := data.Get("metadata_json").(string)
 		var metadata map[string]any
 		json.Unmarshal([]byte(metadata_string), &metadata)
 		client.Metadata = metadata
-		//fmt.Println(client.Metadata)
 	}
 	if o, ok := data.GetOk("owner"); ok {
 		client.Owner = ptr(o.(string))

--- a/internal/provider/resource_oauth2_client_test.go
+++ b/internal/provider/resource_oauth2_client_test.go
@@ -35,6 +35,18 @@ func TestAccResourceOAuth2Client(t *testing.T) {
 					resource.TestCheckResourceAttr("hydra_oauth2_client.secret", "token_endpoint_auth_method", "client_secret_post"),
 				),
 			},
+			{
+				Config: testAccResourceOAuth2ClientWithMetadataJSON,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "client_name", "client_with_metadata_json"),
+					checkResourceAttrJSON("hydra_oauth2_client.client_with_metadata_json", "metadata_json", `{"nested": {"key": "value"}, "first_party": true}`),
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "redirect_uris.#", "1"),
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "redirect_uris.0", "http://localhost:8080/callback"),
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "response_types.#", "1"),
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "response_types.0", "code"),
+					resource.TestCheckResourceAttr("hydra_oauth2_client.client_with_metadata_json", "token_endpoint_auth_method", "none"),
+				),
+			},
 		},
 	})
 }
@@ -66,5 +78,23 @@ resource "hydra_oauth2_client" "secret" {
 	redirect_uris = ["http://localhost:8080/callback"]
 	response_types = ["code"]
 	token_endpoint_auth_method = "client_secret_post"
+}`
+
+	testAccResourceOAuth2ClientWithMetadataJSON = `
+provider "hydra" {
+  endpoint = "http://localhost:4445"
+}
+
+resource "hydra_oauth2_client" "client_with_metadata_json" {
+	client_name = "client_with_metadata_json"
+	metadata_json = jsonencode({
+		"nested" = {
+			"key" = "value"
+		},
+		"first_party" = true
+	})
+	redirect_uris = ["http://localhost:8080/callback"]
+	response_types = ["code"]
+	token_endpoint_auth_method = "none"
 }`
 )


### PR DESCRIPTION
This update introduces the ability to configure the metadata field in OAuth2 clients using the metadata_json parameter, allowing for nested key-value structures. 

The current implementation only supported flat key-value pairs, which limited use cases requiring more complex metadata. With the new approach, users can specify nested metadata by providing it in JSON format. 

The change is backward-compatible, ensuring that existing users relying on the metadata field without JSON can continue without disruption. Both terraform apply and terraform import handle the new format seamlessly.

During terraform import, the provider detects nested metadata and stores it in metadata_json if needed, while simple structures remain in metadata.

Example of usage: 
```
resource "hydra_oauth2_client" "client_with_metadata_json" {
	client_name = "client_with_metadata_json"
	metadata_json = jsonencode({
		"nested" = {
			"key" = "value"
		},
		"first_party" = true
	})
	redirect_uris = ["http://localhost:8080/callback"]
	response_types = ["code"]
	token_endpoint_auth_method = "none"
}
```